### PR TITLE
Fix problem with multiple requests like

### DIFF
--- a/src/TinyTwitter/TinyTwitter.cs
+++ b/src/TinyTwitter/TinyTwitter.cs
@@ -145,7 +145,9 @@ namespace TinyTwitter
 
 				WriteRequestBody(request);
 
-				return request.GetResponse();
+                WebResponse ret=request.GetResponse();
+                request.Abort();
+                return ret;
 			}
 
 			private void WriteRequestBody(HttpWebRequest request)


### PR DESCRIPTION
Fix problem with multiple requests like

var twitter=new TinyTwitter.TinyTwitter(oauth);
twitter.UpdateStatus(".");
twitter.UpdateStatus("..");
twitter.UpdateStatus("..");
twitter.UpdateStatus("....");
twitter.UpdateStatus(".....");

In this case only ».« and »..« are pushed to 
Twitter. After »..« the connections hangs. The
Problem is that HttpWebResponse must be close
after reuse.

HttpWebResponse is now close after use.
