### PR TITLE
Connection was forcefully closed due to securityprotocol.

### DIFF
--- a/src/TinyTwitter/TinyTwitter.cs
+++ b/src/TinyTwitter/TinyTwitter.cs
@@ -35,7 +35,8 @@ namespace TinyTwitter
 		public TinyTwitter(OAuthInfo oauth)
 		{
 			this.oauth = oauth;
-		}
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
+        }
 
 		public void UpdateStatus(string message)
 		{

--- a/src/TinyTwitter/TinyTwitter.csproj
+++ b/src/TinyTwitter/TinyTwitter.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TinyTwitter</RootNamespace>
     <AssemblyName>TinyTwitter</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>


### PR DESCRIPTION
Exception:: 'The underlying connection was closed: An unexpected error occurred on a send.'

Changed .net version of project from 4.0 to 4.5.
Added securityprotocol support for Tls,Tls1.1,Tls1.2,Tls1.3 and Ssl3.